### PR TITLE
Make postgrey work with Perl 5.18

### DIFF
--- a/postgrey
+++ b/postgrey
@@ -557,6 +557,16 @@ sub main()
     if($opt{dbdir}) {
         $opt{dbdir} =~ /^(.*)$/; $opt{dbdir} = $1;
     }
+    # untaint what is given on --pidfile. It is not security sensitive since
+    # it is provided by the admin
+    if($opt{pidfile}) {
+        $opt{pidfile} =~ /^(.*)$/; $opt{pidfile} = $1;
+    }
+    # untaint what is given on --inet. It is not security sensitive since
+    # it is provided by the admin
+    if($opt{inet}) {
+        $opt{inet} =~ /^(.*)$/; $opt{inet} = $1;
+    }
 
     # determine proper "logsock" for Sys::Syslog
     my $syslog_logsock;


### PR DESCRIPTION
Untaint argument of --pidfile and --net options to make postgrey work with Perl 5.18.
