### PR TITLE
Fix auto whitelist

### DIFF
--- a/postgrey
+++ b/postgrey
@@ -443,7 +443,7 @@ sub smtpd_access_policy($$)
     #   - client whitelisted already? -> update last-seen timestamp
     if($self->{postgrey}{awl_clients}) {
         # greylisting succeeded
-        if($diff <= 0 and !$last_was_successful) {
+        if($diff <= 0 and $last_was_successful) {
             # enough time has passed (record only one attempt per hour)
             if(! defined $cawl_last or $now >= $cawl_last + 3600) {
                 # ok, increase count


### PR DESCRIPTION
I always wondered why after many years of using postgrey, I had only 5 clients that had been auto whitelisted. Using postgrey_clients_dump showed 3 were spammers and two were from mailing lists. Upon looking at the code, I noticed a possible mistake in how $last_was_successful is being used. 
Before modification, in order to bump the $cawl_count (which is used to determine whether or not to whitelist), the diff needed to be negative ({delay} - ($now - $first)) and $last_was_successful ($last - $first >= {delay}) needed to be false. This is almost impossible to meet as for diff to be negative, one would be **not** greylisted, and  for $last_was_successful to be false one **would be** greylisted.

Upon removing the negation, postgrey_clients_dump now shows 15 valid clients. 
