### PR TITLE
bugfix: $0 changed to "postgrey"

### DIFF
--- a/postgrey
+++ b/postgrey
@@ -643,7 +643,7 @@ sub main()
         require Digest::SHA;
     }
 
-    $0 = join(' ', @{$server->{server}{commandline}});
+    $0 = 'postgrey';
     $server->run;
 
     # shouldn't get here


### PR DESCRIPTION
In my opinion $0 should either be "postgrey" or "/path/to/postgrey"
 $0 should not contain arguments to the command,
 that is what $1, $2, etc are for.

In other words, use "postgrey" instead of e.g. "postgrey --pidfile=/var/run/postgrey.pid --daemonize --inet=10023"

I think this should actually closes issue#5 https://github.com/schweikert/postgrey/issues/5 instead of d496dfb.

I tried using d496dfb, but the same issue#5 pidof problem remained in debian stable/wheezy. But this pull request fixes the problem. Please review this line change and let me know if you think it's acceptable.
