### PR TITLE
make the init script work as expected

### DIFF
--- a/contrib/postgrey.init
+++ b/contrib/postgrey.init
@@ -22,11 +22,12 @@ set -e
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/sbin/postgrey
-NAME=postgrey
+DAEMON_NAME=postgrey
 DESC="postfix greylisting daemon"
+DAEMON_USER=postgrey
 
-PIDFILE=/var/run/$NAME.pid
-SCRIPTNAME=/etc/init.d/$NAME
+PIDFILE=/var/run/$DAEMON_NAME.pid
+SCRIPTNAME=/etc/init.d/$DAEMON_NAME
 
 # Gracefully exit if the package has been removed.
 test -x $DAEMON || exit 0
@@ -34,9 +35,9 @@ test -x $DAEMON || exit 0
 . /lib/lsb/init-functions
 
 # Read config file if it is present.
-if [ -r /etc/default/$NAME ]
+if [ -r /etc/default/$DAEMON_NAME ]
 then
-    . /etc/default/$NAME
+    . /etc/default/$DAEMON_NAME
 fi
 
 POSTGREY_OPTS="--pidfile=$PIDFILE --daemonize $POSTGREY_OPTS"
@@ -47,49 +48,87 @@ else
 fi
 
 ret=0
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$POSTGREY_OPTS "$POSTGREY_TEXT_OPT" \
+		|| return 2
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --user $DAEMON_USER --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+
+	# Wait for children to finish too if this is a daemon that forks
+	# and if the daemon is only ever run from this initscript.
+	# If the above conditions are not satisfied then add some other code
+	# that waits for the process to drop all resources that could be
+	# needed by services started subsequently.  A last resort is to
+	# sleep for some time.
+	start-stop-daemon --user $DAEMON_USER --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+
+}
+
+do_reload()
+{
+	#
+	# If the daemon can reload its configuration without
+	# restarting (for example, when it is sent a SIGHUP),
+	# then implement that here.
+	#
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE
+	return 0
+}
+
 case "$1" in
   start)
-	log_daemon_msg "Starting $DESC" "$NAME"
-	if start-stop-daemon --start --oknodo --quiet \
-		--pidfile $PIDFILE --name $NAME \
-		--startas $DAEMON -- $POSTGREY_OPTS "$POSTGREY_TEXT_OPT"
-	then
-	    log_end_msg 0
-	else
-	    ret=$?
-	    log_end_msg 1
-	fi
+  [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$DAEMON_NAME"
+	do_start
+	case "$?" in
+	     0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		  2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		  esac
 	;;
   stop)
-	log_daemon_msg "Stopping $DESC" "$NAME"
-	if start-stop-daemon --stop --oknodo --quiet \
-		--pidfile $PIDFILE --name $NAME
-	then
-	    log_end_msg 0
-	else
-	    ret=$?
-	    log_end_msg 1
-	fi
-        rm -f $PIDFILE
+  [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$DAEMON_NAME"
+	do_stop
+	case "$?" in
+	     0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		  2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		  esac
 	;;
   reload|force-reload)
-	log_action_begin_msg "Reloading $DESC configuration..."
-	if start-stop-daemon --stop --signal 1 --quiet \
-		--pidfile $PIDFILE --name $NAME
-	then
-	    log_action_end_msg 0
-	else
-	    ret=$?
-	    log_action_end_msg 1
-	fi
-        ;;
+  [ "$VERBOSE" != no ] && log_daemon_msg "Reloading $DESC" "$DAEMON_NAME"
+	do_reload
+	case "$?" in
+	     0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		  2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		  esac
+	;;
   restart)
-	$0 stop
-	$0 start
-	ret=$?
+	do_stop
+	do_start
 	;;
   status)
-	status_of_proc -p $PIDFILE $DAEMON "$NAME" 2>/dev/null
+	status_of_proc -p $PIDFILE $DAEMON "$DAEMON_NAME" 2>/dev/null
 	ret=$?
 	;;
 


### PR DESCRIPTION
Since package maintainer of Linux distros don't seems to check and upgrade the init script themselves.
For your information, without this patch, as the Ubuntu package of postgrey use this init script for init.d, it can't start, reload configuration, neither stop postgrey.