### PR TITLE
add magisto to whitelist clients

### DIFF
--- a/postgrey_whitelist_clients
+++ b/postgrey_whitelist_clients
@@ -229,3 +229,5 @@ mout-xforward.perfora.net
 gateway.startcom.org
 # French tax authority, no retry
 dgfip.finances.gouv.fr 
+# 2015-06-10 magisto.com (requested by postmaster)
+/^o\d+\.ntdc\.magisto\.com$/


### PR DESCRIPTION
ostensibly, this should have covered all of sendgrid, but it is a large moving target not easily described by current semantics. so this request will cover only magisto FCrDNS / dedicated IP space within sendgrid. if anybody wants to generalize it they are welcome.