### PR TITLE
Add University Erlangen-Nuremberg

### DIFF
--- a/postgrey_whitelist_clients
+++ b/postgrey_whitelist_clients
@@ -287,3 +287,5 @@ github.net
 battle.net
 # 2017-02-09: twitter.com (big pool, #46)
 twitter.com
+# 2017-05-02: rrze.uni-erlangen.de (University Erlangen-Nuremberg (fau.de) uses different IPv4 and IPv6 addresses for their Mailserver)
+rrze.uni-erlangen.de


### PR DESCRIPTION
University Erlangen-Nuremberg (fau.de) uses different IPv4 and IPv6 addresses for their Mailserver under mx-*.rrze.rrze.uni-erlangen.de 
E.g.: 
131.188.11.20
131.188.11.22
2001:638:a000:1025::14
2001:638:a000:1025::16