### PR TITLE
add btinternet.com

### DIFF
--- a/postgrey_whitelist_clients
+++ b/postgrey_whitelist_clients
@@ -308,3 +308,5 @@ cloudflare.net
 me.com
 mimecast.com
 sparkpostmail.com
+# 2024-06-26 btinternet.com (no retry)
+btinternet.com


### PR DESCRIPTION
added btinternet.com after reviewing logs from Mail in a Box server no retry seen from BT owned servers
[mail_extract-anon.log](https://github.com/user-attachments/files/15993361/mail_extract-anon.log)
