### PR TITLE
Add Lettermint to postgrey_whitelist_clients

### DIFF
--- a/postgrey_whitelist_clients
+++ b/postgrey_whitelist_clients
@@ -308,3 +308,5 @@ cloudflare.net
 me.com
 mimecast.com
 sparkpostmail.com
+# 2025-06-22: lettermint.co (reported by @bjarn)
+lmta.net


### PR DESCRIPTION
Lettermint is a transactional ESP from The Netherlands, sending mails from 155.254.62.0/24 from lmta.net.